### PR TITLE
Add GPTable option to include index headings

### DIFF
--- a/gptables/core/gptable.py
+++ b/gptables/core/gptable.py
@@ -29,6 +29,8 @@ class GPTable:
         Default is a level two index in the first column ({2: 0}).
     additional_formatting : dict
         table-specific formatting for columns, rows or individual cells
+    include_index_column_headings : bool
+        indicate whether index column headings should be retained in output
     """
 
     def __init__(self,
@@ -42,7 +44,8 @@ class GPTable:
                  annotations={},
                  notes=[],
                  index_columns={2:0},
-                 additional_formatting=[]
+                 additional_formatting=[],
+                 include_index_column_headings=False
                  ):
         
         # Attributes
@@ -64,6 +67,8 @@ class GPTable:
         self.notes = []
         
         self.additional_formatting = []
+
+        self.include_index_column_headings=include_index_column_headings
         
         # Valid format labels from XlsxWriter
         self._valid_format_labels = [

--- a/gptables/core/wrappers.py
+++ b/gptables/core/wrappers.py
@@ -529,7 +529,8 @@ class GPWorksheet(Worksheet):
         data.loc[-1] = data.columns
         data.index = data.index + 1
         data.sort_index(inplace=True)
-        data.iloc[0, index_columns] = ""  # Delete index col headings
+        if not gptable.include_index_column_headings:
+            data.iloc[0, index_columns] = ""  # Delete index col headings
         
         ## Create formats array
         # pandas.DataFrame did NOT want to hold dictionaries, so be wary
@@ -565,8 +566,9 @@ class GPWorksheet(Worksheet):
         
         
         ## Add Theme formatting to formats dataframe
+        format_headings_from = 0 if gptable.include_index_column_headings else index_levels
         self._apply_format(
-                formats.iloc[0, index_levels:],
+                formats.iloc[0, format_headings_from:],
                 theme.column_heading_format
                 )
         

--- a/gptables/test/test_gptable.py
+++ b/gptables/test/test_gptable.py
@@ -81,6 +81,7 @@ def test_init_defaults(create_gptable_with_kwargs):
     assert empty_gptable.annotations == {}
     assert empty_gptable.notes == []
     assert empty_gptable.additional_formatting == []
+    assert empty_gptable.include_index_column_headings == False
     
     # Other
     assert empty_gptable.index_levels == 0

--- a/gptables/utils/unpickle_themes.py
+++ b/gptables/utils/unpickle_themes.py
@@ -14,7 +14,7 @@ class ThemeUnpickler(pickle.Unpickler):
 
 gptheme = ThemeUnpickler(
         open(
-            resource_filename("gptables", "/theme_pickles/gptheme.pickle"),
+            resource_filename("gptables", "theme_pickles/gptheme.pickle"),
             "rb"
             )
         ).load()


### PR DESCRIPTION
Adds a GPTable option `include_index_column_headings`. Defaults to `False` for backwards compatibility, but when set to `True` the index column headers are displayed and formatted as index headers.

closes #140, closes #130