### PR TITLE
Move note references to end of text elements

### DIFF
--- a/gptables/core/gptable.py
+++ b/gptables/core/gptable.py
@@ -414,8 +414,7 @@ class GPTable:
             ordered_refs.extend(self._get_references(data))
         if isinstance(data, list):
             for n in range(len(data)):
-                if isinstance(data[n], str):
-                    ordered_refs.extend(self._get_references(data[n]))
+                ordered_refs.extend(self._get_references_from_attr(data[n]))
         if isinstance(data, dict):
             for key in data.keys():
                 ordered_refs.extend(self._get_references(data[key]))

--- a/gptables/core/wrappers.py
+++ b/gptables/core/wrappers.py
@@ -111,9 +111,9 @@ class GPWorksheet(Worksheet):
 
     def _reference_annotations(self, gptable, reference_order):
         """
-        Replace note references with numbered references. Acts on `title`,
-        `subtitles`, `table` and `notes` attributes of a GPTable. References 
-        are numbered from top left of spreadsheet, working across each row.
+        Replace note references with numbered references and move to end of element.
+        Acts on `title`, `subtitles`, `table` and `notes` attributes of a GPTable.
+        References are numbered from top left of spreadsheet, working across each row.
         
         Parameters
         ----------
@@ -238,7 +238,7 @@ class GPWorksheet(Worksheet):
         dict_refs = [w.replace("$", "") for w in text_refs]
         for n in range(len(dict_refs)):
             num_ref = "[note " + str(reference_order.index(dict_refs[n]) + 1) + "]"
-            string = string.replace(text_refs[n], num_ref)
+            string = string.replace(text_refs[n], "") + num_ref
 
         return string
 

--- a/gptables/test/test_wrappers.py
+++ b/gptables/test/test_wrappers.py
@@ -245,7 +245,7 @@ class TestGPWorksheetFooterText:
         test_text_dict = {
                 "$$key$$": "This is a value with a $$reference$$",
                 "another_key": "Another value",
-                "third_key": "$$one$$ more reference"
+                "third_key": "$$one$$more reference"
                 }
         got_text = testbook.ws._replace_reference_in_attr(
                 test_text_dict,
@@ -255,7 +255,7 @@ class TestGPWorksheetFooterText:
         exp_text_dict = {
                 "$$key$$": "This is a value with a [note 1]",
                 "another_key": "Another value",
-                "third_key": "[note 2] more reference"
+                "third_key": "more reference[note 2]"
                 }
         
         assert got_text == exp_text_dict


### PR DESCRIPTION
Note: does not integrate fully with custom formatting list - check acceptable use of custom formatting before merging