### PR TITLE
Test note references

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -21,6 +21,7 @@ Unreleased
 * New end-to-end test.
 * New tests for GPWorksheet writing.
 * Validation for tables with only null or whitespace cells
+* Support note references in instructions
 
 **Changed**
 
@@ -35,9 +36,13 @@ Unreleased
 
 * ``contentsheet`` parameter of ``write_workbook`` will be removed in v2 of
   gptables. Please use ``contentsheet_label`` instead.
+* Ability to reference notes within ``GPTable.table.columns`` will be removed
+  in v2 of gptables. Please use ``GPTable.table_notes`` to ensure references
+  are correctly placed and ordered.
 
 **Fixed**
 
+* Fix note order when customising ``description_order`` in ``Theme``
 * Fix special character only cell validation to also include underscore ``_``
 * ``auto_width`` now functions as expected for columns with links or rich text
   columns using Python 3.6 and 3.7, as well as for numeric columns using

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -20,6 +20,7 @@ Unreleased
 * New tests for ``GPTable`` attributes.
 * New end-to-end test.
 * New tests for GPWorksheet writing.
+* New tests for note referencing.
 * Validation for tables with only null or whitespace cells
 * Support note references in instructions
 

--- a/docs/source/doc.gptable.rst
+++ b/docs/source/doc.gptable.rst
@@ -30,6 +30,9 @@ left corner of the first sheet containing a data table.
 
 See this in practice under :ref:`Example Usage`.
 
+.. note:: Deprecated in v1.1.0: Ability to reference notes within
+      ``GPTable.table.columns`` will be removed in v2 of gptables. Please use
+      ``GPTable.table_notes`` to ensure references are correctly placed and ordered.
 
 Links
 -----

--- a/gptables/core/gptable.py
+++ b/gptables/core/gptable.py
@@ -6,7 +6,11 @@ class GPTable:
     """
     A Good Practice Table. Stores a table and metadata for writing a table
     to excel.
-    
+
+    .. note:: Deprecated in v1.1.0: Ability to reference notes within
+        ``GPTable.table.columns`` will be removed in v2 of gptables. Please use
+        ``GPTable.table_notes`` to ensure references are correctly placed and ordered.
+
     Attributes
     ----------
     table : pandas.DataFrame

--- a/gptables/core/gptable.py
+++ b/gptables/core/gptable.py
@@ -446,26 +446,26 @@ class GPTable:
         else:
             self.legend += new_legend
 
-    def _set_annotations(self):
+    def _set_annotations(self, description_order):
         """
         Set a list of note references to the `_annotations` attribute.
         """
         elements = [
                 "title",
                 "subtitles",
-                "legend",
-                "source",
-                "scope",
+                *description_order,
                 "units",
+                "table_notes",
                 ]
-        
+
         ordered_refs = []
-        
+
         for attr in elements:
             attr_current = getattr(self, attr)
             references = self._get_references_from_attr(attr_current)
             ordered_refs.extend(references)
 
+        # Deprecated as of v1.1.0 - instead use `table_notes` to add references to column headers
         table_refs = self._get_references_from_table()
         ordered_refs.extend(table_refs)
 
@@ -504,8 +504,8 @@ class GPTable:
                     ordered_refs.extend(self._get_references(data_list[n]))
 
         return ordered_refs
-        
 
+    # Deprecated as of v1.1.0 - instead use `table_notes` to add references to column headers
     def _get_references_from_table(self):
         """
         Get note references in the table column headings and index columns.

--- a/gptables/core/wrappers.py
+++ b/gptables/core/wrappers.py
@@ -130,15 +130,14 @@ class GPWorksheet(Worksheet):
         -------
         None
         """
+        description_order = self.theme.description_order
+
         elements = [
                 "title",
                 "subtitles",
-                "legend",
-                "source",
-                "scope",
-                "units",
+                *description_order,
                 ]
-        
+
         # Loop through elements, replacing references in strings
         for attr in elements:
             attr_current = getattr(gptable, attr)
@@ -151,9 +150,9 @@ class GPWorksheet(Worksheet):
                             )
                     )
         self._reference_table_annotations(gptable, reference_order)
-        
 
-    def _reference_table_annotations(self, gptable, reference_order): # TODO: properly integrate this with table_notes parameter
+
+    def _reference_table_annotations(self, gptable, reference_order):
         """
         Reference annotations in the table column headings and index columns.
         """
@@ -1026,7 +1025,7 @@ class GPWorkbook(Workbook):
     def _update_annotations(self, sheets):
         ordered_refs = []
         for gptable in sheets.values():
-            gptable._set_annotations()
+            gptable._set_annotations(self.theme.description_order)
             ordered_refs.extend(gptable._annotations)
 
         # remove duplicates from ordered_refs and assign to self._annotations

--- a/gptables/test/test_gptable.py
+++ b/gptables/test/test_gptable.py
@@ -282,7 +282,7 @@ class TestAttrValidationGPTable:
             assert all([element.list == text for element in getattr(gptable, attr)])
         else:
             assert getattr(gptable, attr) == []
-        
+
 
     @pytest.mark.parametrize("key", invalid_text_elements_incl_none[2:] + ["invalid_key"])
     def test_invalid_additional_format_keys(self, key, create_gptable_with_kwargs):
@@ -498,11 +498,11 @@ class TestAttrValidationGPTable:
 
 
 
-@pytest.mark.parametrize("index_cols", valid_index_columns)
 class TestIndirectAttrs:
     """
     Test that non-formatting create_gptable_with_kwargs attributes are indirectly set correctly.
     """
+    @pytest.mark.parametrize("index_cols", valid_index_columns)
     def test_index_levels_set(self, index_cols, create_gptable_with_kwargs):
         """
         Test that number of index levels are set, when one, two or three
@@ -519,8 +519,9 @@ class TestIndirectAttrs:
             "index_columns": index_cols
             })
         assert getattr(gptable, "index_levels") == len(index_cols)
-        
 
+
+    @pytest.mark.parametrize("index_cols", valid_index_columns)
     def test_column_headings_set(self, index_cols, create_gptable_with_kwargs):
         """
         Test that non-index columns are set as column headings.
@@ -540,3 +541,30 @@ class TestIndirectAttrs:
         exp = set(range(4)) - set(range(len(index_cols)))
         
         assert getattr(gptable, "_column_headings") == exp
+
+
+    def test__annotations_set(self, create_gptable_with_kwargs):
+        """
+        Test that annotation references in `gptable` attributes are found and
+        added to `_annotations` as expected.
+        """
+        table = pd.DataFrame(columns=["col"])
+
+        kwargs = {
+            "title": "Title$$1$$",
+            "subtitles": ["Subtitle$$2$$"],
+            "instructions": "Instructions$$3$$",
+            "source": "Source$$4$$",
+            "scope": "Scope$$5$$",
+            "legend": ["Legend$$6$$"],
+            "units": {0: "Unit$$7$$"},
+            "table_notes": {0: "Note$$8$$"},
+            "table": table
+        }
+
+        gptable = create_gptable_with_kwargs(kwargs)
+
+        description_order = ["instructions", "source", "scope", "legend"]
+        gptable._set_annotations(description_order)
+
+        assert gptable._annotations == ["1", "2", "3", "4", "5", "6", "7", "8"]

--- a/gptables/test/test_wrappers.py
+++ b/gptables/test/test_wrappers.py
@@ -257,13 +257,11 @@ class TestGPWorksheetWriting:
 
 
 
-class TestGPWorksheetFooterText:
+class TestGPWorksheetReferences:
     """
-    Test that GPTable footer elements are modified correctly by GPWorksheet
+    Test that GPTable note references are modified correctly by GPWorksheet
     during write_gptable().
     """
-
-
     @pytest.mark.parametrize("text", test_text_list)
     def test__replace_reference(self, text, testbook):
         """
@@ -420,3 +418,36 @@ class TestGPWorkbook:
         """
         with pytest.raises(TypeError):
             testbook.wb.set_theme(not_a_theme)
+
+
+    def test__update_annotations(self, testbook, create_gptable_with_kwargs):
+        """
+        Test that _update_annotations produces a correctly ordered list of
+        note references used in sheets.
+        """
+        table = pd.DataFrame(columns=["col"])
+
+        kwargs1 = {
+            "title": "Title$$1$$",
+            "subtitles": ["Subtitle$$2$$"],
+            "units": {0: "Unit$$3$$"},
+            "table_notes": {0: "Note$$4$$"},
+            "table": table
+        }
+
+        kwargs2 = {
+            "title": "Title$$1$$",
+            "subtitles": ["Subtitle$$3$$"],
+            "units": {0: "Unit$$5$$"},
+            "table_notes": {0: "Note$4$$"},
+            "table": table
+        }
+
+        gptable1 = create_gptable_with_kwargs(kwargs1)
+        gptable2 = create_gptable_with_kwargs(kwargs2)
+        sheets = {"sheet1": gptable1, "sheet2": gptable2}
+
+        gpworkbook = testbook.wb
+        gpworkbook._update_annotations(sheets)
+
+        assert gpworkbook._annotations == ["1", "2", "3", "4", "5"]

--- a/gptables/test/test_wrappers.py
+++ b/gptables/test/test_wrappers.py
@@ -23,13 +23,13 @@ valid_text_elements = [  # Not None
 test_text_list = [
     "This has a $$reference$$",
     "This one doesn't",
-    "Here's another $$one$$"
+    "Here's $$another$$one"
     ]
 
 exp_text_list = [
     "This has a [note 1]",
     "This one doesn't",
-    "Here's another [note 2]"
+    "Here's one[note 2]"
     ]
 
 
@@ -271,25 +271,25 @@ class TestGPWorksheetFooterText:
         [note n], in order of appearance. Also tests replacement in lists.
         """
         got_output = []
-        reference_order = ["reference", "one"]
+        reference_order = ["reference", "another"]
 
         got_output = [testbook.ws._replace_reference(text, reference_order) for text in test_text_list]
     
-        exp_refs = ["reference", "one"]
+        exp_refs = ["reference", "another"]
         assert reference_order == exp_refs
         assert got_output == exp_text_list
 
 
     @pytest.mark.parametrize("text,refs,output",
         zip(test_text_list,
-        [["reference"], [], ["one"]],
-        ["This has a [note 1]", "This one doesn't", "Here's another [note 2]"]
+        [["reference"], [], ["another"]],
+        ["This has a [note 1]", "This one doesn't", "Here's one[note 2]"]
         ))
     def test__replace_reference_in_attr_str(self, text, refs, output, testbook):
         """
         Test that references are replaced in a single string.
         """
-        reference_order = ["reference", "one"]
+        reference_order = ["reference", "another"]
         got_text = testbook.ws._replace_reference_in_attr(
                 text,
                 reference_order
@@ -302,11 +302,11 @@ class TestGPWorksheetFooterText:
         """
         Test that references are replaced in dictionary values, but not keys.
         """
-        reference_order = ["reference", "one"]
+        reference_order = ["reference", "another"]
         test_text_dict = {
                 "$$key$$": "This is a value with a $$reference$$",
-                "another_key": "Another value",
-                "third_key": "$$one$$more reference"
+                "second_key": "Second value",
+                "another_key": "$$another$$reference"
                 }
         got_text = testbook.ws._replace_reference_in_attr(
                 test_text_dict,
@@ -315,8 +315,8 @@ class TestGPWorksheetFooterText:
                 
         exp_text_dict = {
                 "$$key$$": "This is a value with a [note 1]",
-                "another_key": "Another value",
-                "third_key": "more reference[note 2]"
+                "second_key": "Second value",
+                "another_key": "reference[note 2]"
                 }
         
         assert got_text == exp_text_dict

--- a/gptables/test/test_wrappers.py
+++ b/gptables/test/test_wrappers.py
@@ -354,8 +354,23 @@ class TestGPWorksheetFormatUpdate:
         exp.iloc[0] = [{"bold": True} for n in range(3)]
         exp.iloc[1] = [{"bold": True} for n in range(3)]
         assert_frame_equal(test, exp)
-    
-        
+
+
+
+class TestGPWorkbookStatic:
+
+    @pytest.mark.parametrize("input, expected", [
+        ("no references", "no references"),
+        ("ref at end$$1$$", "ref at end"),
+        ("$$1$$ref at start", "ref at start"),
+        ("two$$1$$ refs$$2$$", "two refs"),
+        ("three$$1$$ refs$$2$$, wow$$3$$", "three refs, wow")
+    ])
+    def test__strip_annotation_references(self, input, expected):
+        assert GPWorkbook._strip_annotation_references(input) == expected
+
+
+
 class TestGPWorkbook:
     """
     Test that GPWorkbook initialisation and methods work as expected.


### PR DESCRIPTION
Add tests for finding and modifying note references. Fix note order with customised description order, and deprecate using references in `GPTable.table.columns` (use `GPTable.table_notes` instead)