### PR TITLE
Add accessibility checklist

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -22,7 +22,7 @@ Unreleased
 * New test for marking table as Excel worksheet table.
 * New tests for GPWorksheet writing.
 * New tests for note referencing.
-* Validation for tables with only null or whitespace cells
+* Validation for tables with only null or whitespace rows or cells
 * Support note references in instructions
 
 **Changed**

--- a/docs/source/checklist.rst
+++ b/docs/source/checklist.rst
@@ -1,0 +1,249 @@
+***********************
+Accessibility checklist
+***********************
+
+The tables below indicate your accessibility responsibilities when publishing
+statistics in spreadsheets. It is based on the Analysis Function `checklist of
+the basics`_.
+
+.. _`checklist of the basics`: https://analysisfunction.civilservice.gov.uk/policy-store/making-spreadsheets-accessible-a-brief-checklist-of-the-basics/
+
+.. note:: The tables show which checklist items are automatically met by
+    gptables. This applies to workbooks created using the default ``gptheme``
+    and may not apply if custom themes or additional formatting are used.
+
+Table
+-----
+
+.. list-table::
+    :header-rows: 1
+    :widths: 24 17 19 40
+
+    * - Description
+      - Essential?
+      - Status
+      - Explanation
+    * - Mark up tables
+      - Essential
+      - Implemented
+      - Tables in a ``GPWorkbook``, including notes table and table of contents
+        are marked as tables by default.
+    * - Give tables meaningful names
+      - Recommended
+      - Partially implemented
+      - Pass a meaningful name to the ``GPTable.table_name`` property.
+    * - Remove merged cells, split cells and nested tables
+      - Essential
+      - Implemented
+      - Merged cell, split cells and nested tables are not supported by gptables.
+    * - Remove blank rows and columns within tables
+      - Essential
+      - Implemented
+      - Blank rows or columns in a column will raise an error #TODO: check this
+    * - All tables should have one tagged header row
+      - Essential
+      - Implemented
+      - The column names in a ``GPTable.table`` will be tagged as the header.
+    * - Wrap text within cells
+      - Essential
+      - Partially implemented
+      - Using ``auto_width = True`` (default value) will enable all text to be
+        visible. This feature is experimental and some customisation may be
+        desired.
+    * - Avoid adding filters and freeze panes
+      - Recommended
+      - Implemented
+      - Filters and freeze panes are not supported by gptables.
+    * - Only leave cells with no data empty in certain circumstances
+      - Essential
+      - Partially implemented
+      - If cells are null or whitespace, users are prompted to explain why in the
+        ``GPTables.instructions`` property. If there is more than one reason
+        for missingness, use the `appropriate shorthand`_ and explain in the
+        ``GPTables.legend`` property.
+    * - Avoid hiding rows or columns
+      - Recommended
+      - Implemented
+      - Hiding rows or columns is not supported by gptables.
+
+.. _`appropriate shorthand`: https://analysisfunction.civilservice.gov.uk/policy-store/symbols-in-tables-definitions-and-help/
+
+
+Footnotes
+---------
+
+.. list-table::
+    :header-rows: 1
+    :widths: 24 17 19 40
+
+    * - Description
+      - Essential?
+      - Status
+      - Explanation
+    * - Do not use symbols or superscript to signpost to notes
+      - Essential
+      - Implemented
+      - Notes marked with ``$$note_ref$$`` will be formatted as ``[note n]``,
+        where ``n`` is the order the note appears in the workbook.
+    * - Use the word 'note' when referring to footnotes
+      - Recommended
+      - Implemented
+      - As mentioned above, notes are formatted as ``[note n]``.
+    * - Avoid putting note markers in specific cells
+      - Recommended
+      - Partially implemented
+      - The ``$$note_ref$$`` functionality is not supported within data cells
+        in tables. It is the user's responsibility to not add notes manually to
+        data cells.
+    * - Put note text in a notes table on a notes worksheet
+      - Recommended
+      - Implemented
+      - If users provide a ``notes_table`` when producing or writing a workbook,
+        a notes worksheet will be created.
+
+
+Formatting
+----------
+
+.. list-table::
+    :header-rows: 1
+    :widths: 24 17 19 40
+
+    * - Description
+      - Essential?
+      - Status
+      - Explanation
+    * - All written content needs to meet the accessibility guidelines
+      - Essential
+      - Not implemented
+      - It is the package user's responsibility to make sure that text follows
+        the Analysis Function guidance on `making written content accessible`_.
+    * - Links must be accessible
+      - Essential
+      - Partially implemented
+      - Users should provide descriptive hyperlink text using the
+        ``(display text)[link]`` syntax.
+    * - Format text to make it accessible
+      - Recommended
+      - Implemented
+      - The default theme meets the accessibility guidance on formatting text.
+    * - All worksheets should have descriptive titles which are properly tagged
+        and formatted
+      - Essential
+      - Partially implemented
+      - Provide descriptive titles to the ``GPTable.title`` and ``subtitles``
+        properties. Note: heading tagging in Excel does not meet the standard
+        required of webpage heading tagging.
+    * - Avoid using symbols in general
+      - Recommended
+      - Partially implemented
+      - An error will be raised if table cells only contain symbols. It is the
+        user's responsibility to make sure symbol use within text is appropriate.
+    * - Do not use headers and footers, floating text boxes or floating toolbars
+      - Essential
+      - Implemented
+      - These components are not supported by gptables.
+    * - Do not use visual devices to divide data regions
+      - Recommended
+      - Implemented
+      - Using gptables without additional formatting does not use such visual devices.
+    * - Do not use a background fill
+      - Recommended
+      - Implemented
+      - The gptables default theme does not apply a background fill.
+    * - Do not use colour as the only way to convey a message 
+      - Essential
+      - Implemented
+      - The default theme without additional formatting does not apply colour.
+    * - When using colour for emphasis check the contrast
+      - Essential
+      - Not implemented
+      - If using colour via additional formatting or a custom theme, it is the
+        user's responsibility to check the colour contrast.
+    * - Avoid images in spreadsheets
+      - Recommended
+      - Implemented
+      - Adding images is not supported by gptables.
+    * - Remove macros
+      - Recommended
+      - Implemented
+      - Macros are not supported by gptables.
+
+.. _`making written content accessible`: https://analysisfunction.civilservice.gov.uk/policy-store/making-analytical-publications-accessible/#section-3
+
+
+Structure
+---------
+
+.. list-table::
+    :header-rows: 1
+    :widths: 24 17 19 40
+
+    * - Description
+      - Essential?
+      - Status
+      - Explanation
+    * - Give worksheets unique names or numbers
+      - Essential
+      - Implemented
+      - Worksheet names come from the ``sheets = {"label": gptable}`` property.
+        If names are duplicated, the final ``label: gptable`` pair will be used. #TODO: raise an error?
+    * - Remove blank worksheets
+      - Essential
+      - Implemented
+      - Blank worksheets are not supported by gptables.
+    * - Use cells in column A wisely
+      - Essential
+      - Implemented
+      - ``GPTable`` attributes are written to column A. Title and subtitles are
+        first. The order of the remaining descriptive attributes can be
+        customised by creating a custom theme with a different ``description_order``.
+    * - Position tables against the left-hand edges of each sheet
+      - Essential
+      - Implemented
+      - gptables writes tables starting in column A.
+    * - Avoid putting content below a table
+      - Recommended
+      - Implemented
+      - Writing content below a table is not supported in gptables>=1.0.0.
+    * - Avoid worksheets with multiple tables
+      - Recommended
+      - Implemented
+      - Writing multiple tables per sheet is not supported in gptables.
+
+
+Before publishing
+-----------------
+
+.. list-table::
+    :header-rows: 1
+    :widths: 24 17 19 40
+
+    * - Description
+      - Essential?
+      - Status
+      - Explanation
+    * - Run a spelling and grammar check
+      - Essential
+      - Not implemented
+      - gptables does not check spelling and grammar, this is the user's
+        responsibility.
+    * - Use the accessibility checker
+      - Recommended
+      - Not implemented
+      - gptables does not have a built-in accessibility checker. Whilst all
+        efforts have been taken to make outputs accessible, the final
+        responsibility sits with the user.
+    * - Add document information
+      - Essential
+      - Not implemented
+      - gptables does not add title or language information to the document,
+        this responsibility sits with the user. Note: the document properties
+        available depend on the user's operating system and may not meet
+        the standard required for webpages.
+    * - Ensure the cursor is in cell A1 of the first worksheet when doing your final save
+      - Essential
+      - Implemented
+      - Workbooks written using gptables will have the cursor in the first cell.
+        Note: if the workbook is subsequently opened and saved, it is the user's
+        responsibility to check that the cursor has not been moved.

--- a/docs/source/checklist.rst
+++ b/docs/source/checklist.rst
@@ -188,7 +188,7 @@ Structure
       - Essential
       - Implemented
       - Worksheet names come from the ``sheets = {"label": gptable}`` property.
-        If names are duplicated, the final ``label: gptable`` pair will be used. #TODO: raise an error?
+        If names are duplicated, the final ``label: gptable`` pair will be used.
     * - Remove blank worksheets
       - Essential
       - Implemented

--- a/docs/source/checklist.rst
+++ b/docs/source/checklist.rst
@@ -29,7 +29,7 @@ Table
       - Tables in a ``GPWorkbook``, including notes table and table of contents
         are marked as tables by default.
     * - Give tables meaningful names
-      - Recommended
+      - Desirable
       - Partially implemented
       - Pass a meaningful name to the ``GPTable.table_name`` property.
     * - Remove merged cells, split cells and nested tables
@@ -52,7 +52,7 @@ Table
         visible. This feature is experimental and some customisation may be
         desired.
     * - Avoid adding filters and freeze panes
-      - Recommended
+      - Desirable
       - Implemented
       - Filters and freeze panes are not supported by gptables.
     * - Only leave cells with no data empty in certain circumstances
@@ -63,7 +63,7 @@ Table
         for missingness, use the `appropriate shorthand`_ and explain in the
         ``GPTables.legend`` property.
     * - Avoid hiding rows or columns
-      - Recommended
+      - Desirable
       - Implemented
       - Hiding rows or columns is not supported by gptables.
 
@@ -87,17 +87,17 @@ Footnotes
       - Notes marked with ``$$note_ref$$`` will be formatted as ``[note n]``,
         where ``n`` is the order the note appears in the workbook.
     * - Use the word 'note' when referring to footnotes
-      - Recommended
+      - Desirable
       - Implemented
       - As mentioned above, notes are formatted as ``[note n]``.
     * - Avoid putting note markers in specific cells
-      - Recommended
+      - Desirable
       - Partially implemented
       - The ``$$note_ref$$`` functionality is not supported within data cells
         in tables. It is the user's responsibility to not add notes manually to
         data cells.
     * - Put note text in a notes table on a notes worksheet
-      - Recommended
+      - Desirable
       - Implemented
       - If users provide a ``notes_table`` when producing or writing a workbook,
         a notes worksheet will be created.
@@ -125,7 +125,7 @@ Formatting
       - Users should provide descriptive hyperlink text using the
         ``(display text)[link]`` syntax.
     * - Format text to make it accessible
-      - Recommended
+      - Desirable
       - Implemented
       - The default theme meets the accessibility guidance on formatting text.
     * - All worksheets should have descriptive titles which are properly tagged
@@ -136,7 +136,7 @@ Formatting
         properties. Note: heading tagging in Excel does not meet the standard
         required of webpage heading tagging.
     * - Avoid using symbols in general
-      - Recommended
+      - Desirable
       - Partially implemented
       - An error will be raised if table cells only contain symbols. It is the
         user's responsibility to make sure symbol use within text is appropriate.
@@ -145,11 +145,11 @@ Formatting
       - Implemented
       - These components are not supported by gptables.
     * - Do not use visual devices to divide data regions
-      - Recommended
+      - Desirable
       - Implemented
       - Using gptables without additional formatting does not use such visual devices.
     * - Do not use a background fill
-      - Recommended
+      - Desirable
       - Implemented
       - The gptables default theme does not apply a background fill.
     * - Do not use colour as the only way to convey a message 
@@ -162,11 +162,11 @@ Formatting
       - If using colour via additional formatting or a custom theme, it is the
         user's responsibility to check the colour contrast.
     * - Avoid images in spreadsheets
-      - Recommended
+      - Desirable
       - Implemented
       - Adding images is not supported by gptables.
     * - Remove macros
-      - Recommended
+      - Desirable
       - Implemented
       - Macros are not supported by gptables.
 
@@ -204,11 +204,11 @@ Structure
       - Implemented
       - gptables writes tables starting in column A.
     * - Avoid putting content below a table
-      - Recommended
+      - Desirable
       - Implemented
       - Writing content below a table is not supported in gptables>=1.0.0.
     * - Avoid worksheets with multiple tables
-      - Recommended
+      - Desirable
       - Implemented
       - Writing multiple tables per sheet is not supported in gptables.
 
@@ -230,7 +230,7 @@ Before publishing
       - gptables does not check spelling and grammar, this is the user's
         responsibility.
     * - Use the accessibility checker
-      - Recommended
+      - Desirable
       - Not implemented
       - gptables does not have a built-in accessibility checker. Whilst all
         efforts have been taken to make outputs accessible, the final

--- a/docs/source/checklist.rst
+++ b/docs/source/checklist.rst
@@ -38,8 +38,9 @@ Table
       - Merged cell, split cells and nested tables are not supported by gptables.
     * - Remove blank rows and columns within tables
       - Essential
-      - Implemented
-      - Blank rows or columns in a column will raise an error #TODO: check this
+      - Partially implemented
+      - Blank rows or columns in a column will raise an error. User should
+        remove them and any apply any desired additional formatting.
     * - All tables should have one tagged header row
       - Essential
       - Implemented

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,7 +23,7 @@ Table element mapping:
    :alt: Cells A1 to A6 contain the title, subtitles, instructions, legend, source and scope. These parameters are mapped individually. The next row contains the column headings. Within the same row but on a new line are the units. The table note references are within the same row on a new line under the units. In columns 1, 2 and 3 of the next row down are index levels 1, 2 and 3. In the next columns are the data. Column headings, indices and data are supplied as a pandas DataFrame. Units and table note references are mapped individually.
 
 
-``gptables`` uses the official `guidance on good practice spreadsheets`_
+``gptables`` uses the official `guidance on good practice spreadsheets`_.
 It advocates a strong adherence to the guidance by restricting the range of possible operations.
 The default formatting theme ``gptheme`` accommodates many use cases.
 However, the :class:`~.core.theme.Theme` Class allows development of custom themes, where alternative formatting is required.
@@ -59,5 +59,6 @@ However, the :class:`~.core.theme.Theme` Class allows development of custom them
    doc.theme.rst
    doc.cover.rst
    doc.wrappers.rst
+   checklist.rst
    changelog.rst
    

--- a/gptables/core/gptable.py
+++ b/gptables/core/gptable.py
@@ -182,13 +182,16 @@ class GPTable:
         """
         index_cols = set(self.index_columns.values())
         self._column_headings = {x for x in range(self.table.shape[1])} - index_cols
-    
-    
+
+
     def _validate_all_column_names_have_text(self):
         """
         Validate that all column names in header row have text.
         """
         for column_name in self.table.columns:
+            if pd.isna(column_name):
+                msg = ("Null column name found in table data - column names must all have text")
+                raise ValueError(msg)
             if len(column_name) > 0:
                 continue
             else:

--- a/gptables/core/gptable.py
+++ b/gptables/core/gptable.py
@@ -119,6 +119,7 @@ class GPTable:
 
         self._validate_all_column_names_have_text()
         self._validate_no_duplicate_column_names()
+        self._validate_no_all_null_rows()
 
         if new_index_columns is None:
             new_index_columns = self.index_columns
@@ -196,7 +197,7 @@ class GPTable:
             if pd.isna(column_name):
                 msg = ("Null column name found in table data - column names must all have text")
                 raise ValueError(msg)
-            if len(column_name) > 0:
+            elif len(column_name) > 0:
                 continue
             else:
                 msg = ("Empty column name found in table data - column names must all have text")
@@ -209,6 +210,15 @@ class GPTable:
         """
         if len(self.table.columns) != len(set(self.table.columns)):
             msg = ("Duplicate column names found in table data - column names must be unique")
+            raise ValueError(msg)
+
+
+    def _validate_no_all_null_rows(self):
+        """
+        Validate that there are no rows in table data where all values are null.
+        """
+        if self.table.isna().all(axis=1).any():
+            msg = ("Null row found in table data - remove blank rows before inputting to GPTable")
             raise ValueError(msg)
 
 

--- a/gptables/core/gptable.py
+++ b/gptables/core/gptable.py
@@ -119,7 +119,6 @@ class GPTable:
 
         self._validate_all_column_names_have_text()
         self._validate_no_duplicate_column_names()
-        self._validate_no_all_null_rows()
 
         if new_index_columns is None:
             new_index_columns = self.index_columns
@@ -210,15 +209,6 @@ class GPTable:
         """
         if len(self.table.columns) != len(set(self.table.columns)):
             msg = ("Duplicate column names found in table data - column names must be unique")
-            raise ValueError(msg)
-
-
-    def _validate_no_all_null_rows(self):
-        """
-        Validate that there are no rows in table data where all values are null.
-        """
-        if self.table.isna().all(axis=1).any():
-            msg = ("Null row found in table data - remove blank rows before inputting to GPTable")
             raise ValueError(msg)
 
 

--- a/gptables/core/wrappers.py
+++ b/gptables/core/wrappers.py
@@ -471,7 +471,6 @@ class GPWorksheet(Worksheet):
             select if column widths should be determined automatically using
             length of text in index and columns
 
-
         Returns
         -------
         pos : list
@@ -481,17 +480,25 @@ class GPWorksheet(Worksheet):
         gptable.table.replace({r'^\s*$': None}, inplace=True, regex=True)
 
         if gptable.table.isna().values.all():
-            msg = ("""
-            Table found containing only null or whitespace cells.
+            msg = (f"""
+            {gptable.table_name} contains only null or whitespace cells.
             Please provide alternative table containing data.
             """)
             raise ValueError(msg)
 
+        if gptable.table.isna().all(axis=1).any():
+            msg = (f"""
+            Empty or null row found in {gptable.table_name}.
+            Please remove blank rows before passing data to GPTable.
+            """)
+            raise ValueError(msg)
+
         if gptable.table.isna().values.any():
-            msg = ("""
-            Empty or null cell found in table, the reason for missingness should
-            be included above the table before inputting to gptables.
-            There should only be one reason otherwise a shorthand should be provided.
+            msg = (f"""
+            Empty or null cell found in {gptable.table_name}. The reason for
+            missingness should be included in the `GPTable.instructions` attribute.
+            There should only be one reason otherwise a shorthand should be
+            provided in the `instructions` or `legend` attribute.
             Guidance on shorthand can be found at:
             https://analysisfunction.civilservice.gov.uk/policy-store/symbols-in-tables-definitions-and-help/
             """)
@@ -499,9 +506,9 @@ class GPWorksheet(Worksheet):
 
         # Raise error if any table element is only special characters
         if gptable.table.stack().str.contains('^[^a-zA-Z0-9]*$').any():
-            msg = ("""
-            Cell found containing only special characters, replace with
-            alphanumeric characters before inputting to gptables.
+            msg = (f"""
+            Cell found in {gptable.table_name} containing only special characters,
+            replace with alphanumeric characters before inputting to GPTable.
             Guidance on symbols in tables can be found at:
             https://analysisfunction.civilservice.gov.uk/policy-store/symbols-in-tables-definitions-and-help/
             """)

--- a/gptables/test/test_gptable.py
+++ b/gptables/test/test_gptable.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
@@ -470,12 +471,13 @@ class TestAttrValidationGPTable:
 
 
     @pytest.mark.parametrize("column_names,expectation", [
-        (["columnA", "columnB", "columnC"], does_not_raise()),
-        (["columnA", "columnB", ""], pytest.raises(ValueError))
+        (["columnA", "columnB"], does_not_raise()),
+        (["columnA", ""], pytest.raises(ValueError)),
+        ([None, "columnB"], pytest.raises(ValueError))
     ])
-    def test_validate_all_column_names_have_text(self, column_names, expectation, create_gptable_with_kwargs):
+    def test__validate_all_column_names_have_text(self, column_names, expectation, create_gptable_with_kwargs):
         """
-        Test that GPTable raises error when there are empty strings for column names.
+        Test that GPTable raises error when there are null values or empty strings for column names.
         """
         with expectation:
             create_gptable_with_kwargs({
@@ -487,7 +489,7 @@ class TestAttrValidationGPTable:
         (["columnA", "columnB", "columnC"], does_not_raise()),
         (["columnA", "columnB", "columnB"], pytest.raises(ValueError))
     ])
-    def test_validate_no_duplicate_column_names(self, column_names, expectation, create_gptable_with_kwargs):
+    def test__validate_no_duplicate_column_names(self, column_names, expectation, create_gptable_with_kwargs):
         """
         Test that GPTable raises error when there are duplicate column names in table data.
         """

--- a/gptables/test/test_wrappers.py
+++ b/gptables/test/test_wrappers.py
@@ -236,8 +236,15 @@ class TestGPWorksheetWriting:
         assert len(cell) == 1
 
 
+    def test__write_empty_table(self, testbook, create_gptable_with_kwargs):
+        gptable = create_gptable_with_kwargs({
+            "table": pd.DataFrame({"col": [None]})
+        })
+        with pytest.raises(ValueError):
+            testbook.ws._write_table_elements([0,0], gptable, auto_width=True)
+
+
     @pytest.mark.parametrize("cell_value1,cell_value2,expectation", [
-        (None, None, pytest.raises(ValueError)),
         (None, "valid text", pytest.warns(UserWarning)),
         ("", "valid text", pytest.warns(UserWarning)),
         (" ", "valid text", pytest.warns(UserWarning)),
@@ -246,12 +253,14 @@ class TestGPWorksheetWriting:
         (" *", "valid text", pytest.raises(ValueError)),
         (" Hello_World! ", "valid text", does_not_raise()),
     ])
-    def test__write_table_elements_validation(self, testbook,
+    def test__write_table_elements_cell_validation(self, testbook,
         create_gptable_with_kwargs, cell_value1, cell_value2, expectation):
         gptable = create_gptable_with_kwargs({
-            "table": pd.DataFrame({"col": [cell_value1, cell_value2]})
+            "table": pd.DataFrame({
+                "colA": [cell_value1, cell_value2],
+                "colB": ["valid text", "valid text"]
+            })
         })
-
         with expectation:
             testbook.ws._write_table_elements([0,0], gptable, auto_width=True)
 


### PR DESCRIPTION
Add checklist as per [a11ytables](https://co-analysis.github.io/a11ytables/articles/accessibility-checklist.html), based off [AF checklist](https://analysisfunction.civilservice.gov.uk/policy-store/making-spreadsheets-accessible-a-brief-checklist-of-the-basics/)