### PR TITLE
Test column width

### DIFF
--- a/gptables/core/wrappers.py
+++ b/gptables/core/wrappers.py
@@ -959,7 +959,7 @@ class GPWorksheet(Worksheet):
         elif isinstance(cell_val, dict):
             max_length = self._longest_line_length(list(cell_val)[0])
         elif isinstance(cell_val, FormatList):
-            max_length = self._longest_line_length(cell_val.sting)
+            max_length = self._longest_line_length(cell_val.string)
         elif isinstance(cell_val, list):
             if isinstance(cell_val[0], (dict, FormatList)):
                 max_length = self._longest_line_length(cell_val[0])

--- a/gptables/test/test_wrappers.py
+++ b/gptables/test/test_wrappers.py
@@ -422,6 +422,22 @@ class TestGPWorksheetTable:
         assert got_length == exp_length
 
 
+    @pytest.mark.parametrize("data", [
+        ["string", "longer string"],
+        ["longer string", "longer string"]])
+    @pytest.mark.parametrize("format", [
+        [{"font_size": 12}, {"font_size": 12}],
+        [{"font_size": 10}, {"font_size": 12}]])
+    def test__calculate_column_widths(self, testbook, data, format):
+        table = pd.DataFrame({"col": data})
+        table_format = pd.DataFrame({"col": format})
+
+        got_width = testbook.ws._calculate_column_widths(table, table_format)
+        exp_width = testbook.ws._excel_string_width(string_len=11, font_size=12)
+
+        assert got_width == exp_width
+
+
 
 class TestGPWorkbook:
     """

--- a/gptables/test/test_wrappers.py
+++ b/gptables/test/test_wrappers.py
@@ -405,6 +405,23 @@ class TestGPWorksheetTable:
             assert got_heading_format.__dict__ == exp_heading_format.__dict__
 
 
+    @pytest.mark.parametrize("cell_val,exp_length",[
+        ("string", 6),
+        (42, 2),
+        (3.14, 4),
+        ({"gov.uk": "https://www.gov.uk"}, 6),
+        (FormatList(["Partially ", {"bold": True}, "bold", " string"]), 21),
+        (["string", "another string"], 14),
+        ("string\nwith\nnewlines", 8),
+        (FormatList(["string\r\n", {"bold": True}, "bold string"]), 11),
+        (set(), 0)
+    ])
+    def test__longest_line_length(self, testbook, cell_val, exp_length):
+        got_length = testbook.ws._longest_line_length(cell_val)
+
+        assert got_length == exp_length
+
+
 
 class TestGPWorkbook:
     """

--- a/gptables/test/test_wrappers.py
+++ b/gptables/test/test_wrappers.py
@@ -433,7 +433,7 @@ class TestGPWorksheetTable:
         table_format = pd.DataFrame({"col": format})
 
         got_width = testbook.ws._calculate_column_widths(table, table_format)
-        exp_width = testbook.ws._excel_string_width(string_len=11, font_size=12)
+        exp_width = [testbook.ws._excel_string_width(string_len=13, font_size=12)]
 
         assert got_width == exp_width
 

--- a/gptables/test/test_wrappers.py
+++ b/gptables/test/test_wrappers.py
@@ -424,7 +424,8 @@ class TestGPWorksheetTable:
 
     @pytest.mark.parametrize("data", [
         ["string", "longer string"],
-        ["longer string", "longer string"]])
+        ["longer string", "longer string"],
+        ["string\nstring\nstring", "longer string"]])
     @pytest.mark.parametrize("format", [
         [{"font_size": 12}, {"font_size": 12}],
         [{"font_size": 10}, {"font_size": 12}]])


### PR DESCRIPTION
Two tests added relating to column width: `test__longest_line_length` and `test__calculate_column_width`. Tests not added for `_excel_string_width` or `_set_column_width` as these are comparatively simple applications of base python and xlsxwriter functions respectively.

Query: is `TestGPWorksheetTable` class appropriate place for these tests? 