### PR TITLE
Refactor test_valid_text_in_list_attrs

### DIFF
--- a/gptables/test/test_gptable.py
+++ b/gptables/test/test_gptable.py
@@ -269,20 +269,14 @@ class TestAttrValidationGPTable:
         Test that setting list of valid text elements to GPTable list
         parameters works as expected.
         """
-        if text is not None:
-            text_list = [text, text]
-        else:
-            text_list = []
-
+        text_list = [text, text]
         gptable = create_gptable_with_kwargs({attr: text_list})
 
-        if isinstance(text, str):
-            assert getattr(gptable, attr) == text_list
-        elif isinstance(text, list):
+        if isinstance(text, list):
             assert all([element.list == text for element in getattr(gptable, attr)])
         else:
-            assert getattr(gptable, attr) == []
-        
+            assert getattr(gptable, attr) == text_list
+
 
     @pytest.mark.parametrize("key", invalid_text_elements_incl_none[2:] + ["invalid_key"])
     def test_invalid_additional_format_keys(self, key, create_gptable_with_kwargs):


### PR DESCRIPTION
Small refactoring of test_valid_text_in_list_attrs. No further refactoring done as:
- Storing gptable attr lists in GPTable rather than test_gptable mainly makes sense if GPTable is refactored to use these lists, which isn't a current priority
- Refactoring text attr tests to separate tests for text vs rich text would introduce repetition and the tests are fairly clear as they are - please flag when reviewing if you think refactoring them into separate tests would make them clearer