### PR TITLE
Added to requirements that dataclasses are only required for python v…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pandas>=0.25.3
 xlrd>=1.2.0
 XlsxWriter>=1.2.6
 pyyaml>=3.12
-dataclasses
+dataclasses;python_version<"3.7"


### PR DESCRIPTION
Specified in the requirements that the dataclasses package only needs to be downloaded for python <3.7