### PR TITLE
change a11ytables to aftables, fix links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ machine-readable CSV-W files.
 .. _`Analysis Function`: https://analysisfunction.civilservice.gov.uk/
 .. _`PyPI`: https://pypi.org/project/gptables/
 .. _`GitHub`: https://github.com/best-practice-and-impact/gptables
-.. _`a11ytables`: https://co-analysis.github.io/a11ytables/index.html
+.. _`aftables`: https://github.com/best-practice-and-impact/aftables
 .. _`csvcubed`: https://gss-cogs.github.io/csvcubed-docs/external/
 
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,7 +14,11 @@ and this project tries its very best to adhere to
 
 Unreleased
 ===================
+:Date: 2025-02-25
 
+**Changed**
+
+* a11ytables renamed to aftables throughout
 
 Released (PyPI)
 ===============

--- a/docs/source/checklist.rst
+++ b/docs/source/checklist.rst
@@ -4,10 +4,10 @@ Accessibility checklist
 
 The tables below indicate your accessibility responsibilities when publishing
 statistics in spreadsheets. It is based on the Analysis Function `checklist of
-the basics`_ and heavily inspired by the `a11ytables documentation`_.
+the basics`_ and heavily inspired by the `aftables documentation`_.
 
 .. _`checklist of the basics`: https://analysisfunction.civilservice.gov.uk/policy-store/making-spreadsheets-accessible-a-brief-checklist-of-the-basics/
-.. _`a11ytables documentation`: https://co-analysis.github.io/a11ytables/articles/checklist.html
+.. _`aftables documentation`: https://best-practice-and-impact.github.io/aftables/articles/checklist.html
 
 .. note:: The tables show which checklist items are automatically met by
     gptables. This applies to workbooks created using the default ``gptheme``

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,7 +30,7 @@ However, the :class:`~.core.theme.Theme` Class allows development of custom them
 
 ``gptables`` is developed and maintained by the `Analysis Function`_. It can be
 installed from `PyPI`_ or `GitHub`_. The source code is maintained on GitHub.
-Users may also be interested in `a11ytables`_, an R native equivalent to
+Users may also be interested in `aftables`_, an R native equivalent to
 ``gptables``, and `csvcubed`_, a package for turning data and metadata into
 machine-readable CSV-W files.
 
@@ -38,7 +38,7 @@ machine-readable CSV-W files.
 .. _`Analysis Function`: https://analysisfunction.civilservice.gov.uk/
 .. _`PyPI`: https://pypi.org/project/gptables/
 .. _`GitHub`: https://github.com/best-practice-and-impact/gptables
-.. _`a11ytables`: https://co-analysis.github.io/a11ytables/index.html
+.. _`aftables`: https://best-practice-and-impact.github.io/aftables/
 .. _`csvcubed`: https://gss-cogs.github.io/csvcubed-docs/external/
 
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -68,5 +68,5 @@ R Usage
 
 Use of ``gptables`` in R requires use of python via the `reticulate <https://rstudio.github.io/reticulate/>`_ package.
 
-However we recommend use of the `a11ytables <https://co-analysis.github.io/a11ytables/>`_
-R package, developed by the Cabinet Office.
+However we recommend use of the `aftables <https://github.com/best-practice-and-impact/aftables>`_
+R package, maintained by the Presentation Champions Data Visualisation Tools subgroup.


### PR DESCRIPTION
a11ytables has been renamed to aftables. I have updated this throughout with links and the team who now maintain this.