### PR TITLE
Update actions from v2 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
         python-version: ['3.11']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Python dependencies
@@ -53,9 +53,9 @@ jobs:
 
         
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Python dependencies
@@ -76,12 +76,12 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: ~\AppData\Local\pip\Cache
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
@@ -100,12 +100,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.11
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.11'
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: ~\AppData\Local\pip\Cache
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
@@ -131,7 +131,7 @@ jobs:
         id-token: write
       steps:
         - name: Checkout source
-          uses: actions/checkout@v2
+          uses: actions/checkout@v4
         - name: Set up Python 3.11
           uses: actions/setup-python@v1
           with:


### PR DESCRIPTION
"Starting February 1st, 2025, Actions’ cache storage will move to a new architecture, as a result we are closing down v1-v2 of actions/cache. In conjunction, all previous versions of the [@actions/cache package](https://github.com/actions/toolkit/blob/main/packages/cache/README.md) (prior to 4.0.0) in actions/toolkit will be closing down. The action and cache package will be fully retired on March 1st."

https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down