### PR TITLE
fix bug to allow formatting of multiple individual cells

### DIFF
--- a/gptables/core/wrappers.py
+++ b/gptables/core/wrappers.py
@@ -601,10 +601,7 @@ class GPWorksheet(Worksheet):
                 for row, col in cell_ilocs:
                     formats_table_slice = formats_table.iloc[row, col]
 
-                    self._apply_format(formats_table_slice, formatting)
-                continue
-
-            if fmt_type == "column":
+            elif fmt_type == "column":
                 cols_iloc = [
                     formats_table.columns.get_loc(col) if isinstance(col, str) else col
                     for col in format_desc["columns"]


### PR DESCRIPTION
### Proposed Changes
  - update apply_additional_formatting to enable multiple "cell" keys to be supplied to additional_formatting 
  - Part fixes #239 

### Related Issues
  - Related to #
  - Fixes #

### Pre-requisites
This section may not be fully required if the branch is not merging into main.
Please indicate items that aren't necessary and why, with comments around incomplete checks.

- [ ] Version number has been incremented, according to [SemVer][semver]
- [ ] Changelog has been updated, listing changes to this version. Use the [keep a changelog][changelog] format
- [ ] New features are tested
- [ ] New features are documented using the [numpydoc][numpy-docstrings] docstring format
- [ ] Other relevant package documentation is updated
- [ ] For new functionality, examples are included in the docs or a [feature request][feature-request] has 
been made for it/them.

[changelog]: [https://keepachangelog.com/en/1.0.0/]
[feature-request]: [https://github.com/best-practice-and-impact/gptables/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=]
[numpy-docstrings]: [https://numpydoc.readthedocs.io/en/latest/format.html]
[semver]: [https://semver.org/spec/v2.0.0.html]
