### PR TITLE
blue in python is #0000FF which passes the WCAG AA contrast check, ad…

### DIFF
--- a/gptables/core/wrappers.py
+++ b/gptables/core/wrappers.py
@@ -827,7 +827,9 @@ class GPWorksheet(Worksheet):
         display_text = list(data.keys())[0]
 
         url_format = format_dict.copy()
-        url_format.update({"underline": True, "font_color": "blue"}) # blue == #0000FF - passes WCAG AA contrast check
+        url_format.update(
+            {"underline": True, "font_color": "blue"}
+        )  # blue == #0000FF - passes WCAG AA contrast check
 
         self.write_url(
             row, col, url, workbook.add_format(url_format), display_text, *args


### PR DESCRIPTION
I confirmed from documentation that Python/Pandas 's 'blue' is #0000ff in HEX. I then checked this in the suggested colour contrast checking tool, which passed: https://webaim.org/resources/contrastchecker 

I didn't update the colour as a result, I only added a comment next to the url formatting function which says the 'blue' is #0000ff and that this passes WCAG AA standards.
